### PR TITLE
[3주차 PR] Issue#8 카테고리 CRUD 구현

### DIFF
--- a/src/main/java/com/zerobase/accountbook/common/config/config/security/SecurityConfig.java
+++ b/src/main/java/com/zerobase/accountbook/common/config/config/security/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
-                .antMatchers("/v1/auth/**").permitAll()
+                .antMatchers("/v1/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),

--- a/src/main/java/com/zerobase/accountbook/common/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/accountbook/common/exception/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     NOT_FOUND_ROOM_EXCEPTION(NOT_FOUND, "삭제되었거나 존재하지 않는 방입니다"),
     NOT_FOUND_FEED_EXCEPTION(NOT_FOUND, "삭제되었거나 존재하지 않는 피드입니다"),
     NOT_FOUND_EMAIL_EXCEPTION(NOT_FOUND, "가입되지 않은 이메일입니다."),
+    NOT_FOUND_CATEGORY_EXCEPTION(NOT_FOUND, "존재하지 않는 카테고리입니다."),
 
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED_EXCEPTION(METHOD_NOT_ALLOWED, "지원하지 않는 메소드 입니다"),

--- a/src/main/java/com/zerobase/accountbook/common/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/accountbook/common/exception/ErrorCode.java
@@ -59,6 +59,7 @@ public enum ErrorCode {
     CONFLICT_EXCEPTION(CONFLICT, "이미 존재합니다"),
     CONFLICT_EMAIL_EXCEPTION(CONFLICT, "이미 사용중인 이메일입니다.\n다른 이메일을 이용해주세요"),
     CONFLICT_USER_EXCEPTION(CONFLICT, "이미 해당 계정으로 회원가입하셨습니다.\n로그인 해주세요"),
+    CONFLIC_CATEGORY_NAME_EXCEPTION(CONFLICT, "이미 존재하는 카테고리 이름입니다."),
 
     // 415 Unsupported Media Type
     UNSUPPORTED_MEDIA_TYPE_EXCEPTION(UNSUPPORTED_MEDIA_TYPE, "해당하는 미디어 타입을 지원하지 않습니다."),

--- a/src/main/java/com/zerobase/accountbook/controller/category/CategoryController.java
+++ b/src/main/java/com/zerobase/accountbook/controller/category/CategoryController.java
@@ -2,13 +2,12 @@ package com.zerobase.accountbook.controller.category;
 
 import com.zerobase.accountbook.common.dto.ApiResponse;
 import com.zerobase.accountbook.controller.category.dto.request.CreateCategoryRequestDto;
+import com.zerobase.accountbook.controller.category.dto.request.ModifyCategoryRequestDto;
 import com.zerobase.accountbook.controller.category.dto.response.CreateCategoryResponseDto;
+import com.zerobase.accountbook.controller.category.dto.response.ModifyCategoryResponseDto;
 import com.zerobase.accountbook.service.category.CategoryService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -24,6 +23,14 @@ public class CategoryController {
             @Valid @RequestBody CreateCategoryRequestDto request
     ) {
         CreateCategoryResponseDto response = categoryService.createCategory(request);
+        return ApiResponse.success(response);
+    }
+
+    @PutMapping("/modify")
+    public ApiResponse<ModifyCategoryResponseDto> modifyCategory(
+            @Valid @RequestBody ModifyCategoryRequestDto request
+    ) {
+        ModifyCategoryResponseDto response = categoryService.modifyCategory(request);
         return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/zerobase/accountbook/controller/category/CategoryController.java
+++ b/src/main/java/com/zerobase/accountbook/controller/category/CategoryController.java
@@ -21,7 +21,7 @@ public class CategoryController {
 
     private final CategoryService categoryService;
 
-    @PostMapping("/create")
+    @PostMapping()
     public ApiResponse<CreateCategoryResponseDto> createCategory(
             @Valid @RequestBody CreateCategoryRequestDto request
     ) {
@@ -29,7 +29,7 @@ public class CategoryController {
         return ApiResponse.success(response);
     }
 
-    @PutMapping("/modify")
+    @PutMapping()
     public ApiResponse<ModifyCategoryResponseDto> modifyCategory(
             @Valid @RequestBody ModifyCategoryRequestDto request
     ) {
@@ -37,7 +37,7 @@ public class CategoryController {
         return ApiResponse.success(response);
     }
 
-    @DeleteMapping("/delete")
+    @DeleteMapping()
     public ApiResponse<String> deleteCategory(
             @Valid @RequestBody DeleteCategoryRequestDto request
     ) {

--- a/src/main/java/com/zerobase/accountbook/controller/category/CategoryController.java
+++ b/src/main/java/com/zerobase/accountbook/controller/category/CategoryController.java
@@ -1,0 +1,14 @@
+package com.zerobase.accountbook.controller.category;
+
+import com.zerobase.accountbook.service.category.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/category")
+@RestController
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+}

--- a/src/main/java/com/zerobase/accountbook/controller/category/CategoryController.java
+++ b/src/main/java/com/zerobase/accountbook/controller/category/CategoryController.java
@@ -5,12 +5,14 @@ import com.zerobase.accountbook.controller.category.dto.request.CreateCategoryRe
 import com.zerobase.accountbook.controller.category.dto.request.DeleteCategoryRequestDto;
 import com.zerobase.accountbook.controller.category.dto.request.ModifyCategoryRequestDto;
 import com.zerobase.accountbook.controller.category.dto.response.CreateCategoryResponseDto;
+import com.zerobase.accountbook.controller.category.dto.response.GetCategoryListResponseDto;
 import com.zerobase.accountbook.controller.category.dto.response.ModifyCategoryResponseDto;
 import com.zerobase.accountbook.service.category.CategoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RequestMapping("/v1/category")
 @RestController
@@ -41,5 +43,11 @@ public class CategoryController {
     ) {
         categoryService.deleteCategory(request);
         return ApiResponse.SUCCESS;
+    }
+
+    @GetMapping("/list")
+    public ApiResponse<List<GetCategoryListResponseDto>> getCategoryList() {
+        List<GetCategoryListResponseDto> response = categoryService.getCategoryList();
+        return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/zerobase/accountbook/controller/category/CategoryController.java
+++ b/src/main/java/com/zerobase/accountbook/controller/category/CategoryController.java
@@ -1,14 +1,29 @@
 package com.zerobase.accountbook.controller.category;
 
+import com.zerobase.accountbook.common.dto.ApiResponse;
+import com.zerobase.accountbook.controller.category.dto.request.CreateCategoryRequestDto;
+import com.zerobase.accountbook.controller.category.dto.response.CreateCategoryResponseDto;
 import com.zerobase.accountbook.service.category.CategoryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/category")
+import javax.validation.Valid;
+
+@RequestMapping("/v1/category")
 @RestController
 @RequiredArgsConstructor
 public class CategoryController {
 
     private final CategoryService categoryService;
+
+    @PostMapping("/create")
+    public ApiResponse<CreateCategoryResponseDto> createCategory(
+            @Valid @RequestBody CreateCategoryRequestDto request
+    ) {
+        CreateCategoryResponseDto response = categoryService.createCategory(request);
+        return ApiResponse.success(response);
+    }
 }

--- a/src/main/java/com/zerobase/accountbook/controller/category/CategoryController.java
+++ b/src/main/java/com/zerobase/accountbook/controller/category/CategoryController.java
@@ -2,6 +2,7 @@ package com.zerobase.accountbook.controller.category;
 
 import com.zerobase.accountbook.common.dto.ApiResponse;
 import com.zerobase.accountbook.controller.category.dto.request.CreateCategoryRequestDto;
+import com.zerobase.accountbook.controller.category.dto.request.DeleteCategoryRequestDto;
 import com.zerobase.accountbook.controller.category.dto.request.ModifyCategoryRequestDto;
 import com.zerobase.accountbook.controller.category.dto.response.CreateCategoryResponseDto;
 import com.zerobase.accountbook.controller.category.dto.response.ModifyCategoryResponseDto;
@@ -32,5 +33,13 @@ public class CategoryController {
     ) {
         ModifyCategoryResponseDto response = categoryService.modifyCategory(request);
         return ApiResponse.success(response);
+    }
+
+    @DeleteMapping("/delete")
+    public ApiResponse<String> deleteCategory(
+            @Valid @RequestBody DeleteCategoryRequestDto request
+    ) {
+        categoryService.deleteCategory(request);
+        return ApiResponse.SUCCESS;
     }
 }

--- a/src/main/java/com/zerobase/accountbook/controller/category/dto/request/CreateCategoryRequestDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/category/dto/request/CreateCategoryRequestDto.java
@@ -1,0 +1,15 @@
+package com.zerobase.accountbook.controller.category.dto.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateCategoryRequestDto {
+
+    private String memberEmail;
+
+    private String categoryName;
+}

--- a/src/main/java/com/zerobase/accountbook/controller/category/dto/request/DeleteCategoryRequestDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/category/dto/request/DeleteCategoryRequestDto.java
@@ -1,0 +1,20 @@
+package com.zerobase.accountbook.controller.category.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteCategoryRequestDto {
+
+    @Email
+    private String memberEmail;
+
+    private long categoryId;
+}

--- a/src/main/java/com/zerobase/accountbook/controller/category/dto/request/ModifyCategoryRequestDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/category/dto/request/ModifyCategoryRequestDto.java
@@ -9,10 +9,12 @@ import javax.validation.constraints.Email;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CreateCategoryRequestDto {
+public class ModifyCategoryRequestDto {
 
     @Email
     private String memberEmail;
+
+    private long categoryId;
 
     private String categoryName;
 }

--- a/src/main/java/com/zerobase/accountbook/controller/category/dto/response/CreateCategoryResponseDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/category/dto/response/CreateCategoryResponseDto.java
@@ -1,0 +1,20 @@
+package com.zerobase.accountbook.controller.category.dto.response;
+
+import com.zerobase.accountbook.domain.category.Category;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateCategoryResponseDto {
+
+    private String categoryName;
+
+    public static CreateCategoryResponseDto of(Category category) {
+        return CreateCategoryResponseDto.builder()
+                .categoryName(category.getCategoryName())
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/accountbook/controller/category/dto/response/GetCategoryListResponseDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/category/dto/response/GetCategoryListResponseDto.java
@@ -1,0 +1,20 @@
+package com.zerobase.accountbook.controller.category.dto.response;
+
+import com.zerobase.accountbook.domain.category.Category;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetCategoryListResponseDto {
+
+    private String categoryName;
+
+    public static GetCategoryListResponseDto of(Category category) {
+        return GetCategoryListResponseDto.builder()
+                .categoryName(category.getCategoryName())
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/accountbook/controller/category/dto/response/ModifyCategoryResponseDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/category/dto/response/ModifyCategoryResponseDto.java
@@ -8,15 +8,12 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CreateCategoryResponseDto {
-
-    private long categoryId;
+public class ModifyCategoryResponseDto {
 
     private String categoryName;
 
-    public static CreateCategoryResponseDto of(Category category) {
-        return CreateCategoryResponseDto.builder()
-                .categoryId(category.getId())
+    public static ModifyCategoryResponseDto of(Category category) {
+        return ModifyCategoryResponseDto.builder()
                 .categoryName(category.getCategoryName())
                 .build();
     }

--- a/src/main/java/com/zerobase/accountbook/domain/category/Category.java
+++ b/src/main/java/com/zerobase/accountbook/domain/category/Category.java
@@ -1,0 +1,34 @@
+package com.zerobase.accountbook.domain.category;
+
+import com.zerobase.accountbook.domain.member.Member;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Setter
+@Getter
+@Entity
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "MEMBER_ID")
+    private Member member;
+
+    private String categoryName;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/zerobase/accountbook/domain/category/CategoryRepository.java
+++ b/src/main/java/com/zerobase/accountbook/domain/category/CategoryRepository.java
@@ -1,0 +1,6 @@
+package com.zerobase.accountbook.domain.category;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/zerobase/accountbook/domain/category/CategoryRepository.java
+++ b/src/main/java/com/zerobase/accountbook/domain/category/CategoryRepository.java
@@ -1,6 +1,9 @@
 package com.zerobase.accountbook.domain.category;
 
+import org.springframework.data.domain.Example;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    boolean existsByCategoryName(String categoryName);
 }

--- a/src/main/java/com/zerobase/accountbook/service/category/CategoryService.java
+++ b/src/main/java/com/zerobase/accountbook/service/category/CategoryService.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.zerobase.accountbook.common.exception.ErrorCode.*;
@@ -29,11 +28,12 @@ public class CategoryService {
 
     private final MemberRepository memberRepository;
 
-    public CreateCategoryResponseDto createCategory(CreateCategoryRequestDto request) {
+    public CreateCategoryResponseDto createCategory(
+            CreateCategoryRequestDto request
+    ) {
 
         Member member = validateMember(request.getMemberEmail());
-        
-        // 생성하려는 카테고리 이름이 중복될 경우
+
         validateUniqueCategoryName(request.getCategoryName());
 
         return CreateCategoryResponseDto.of(categoryRepository.save(Category.builder()
@@ -43,22 +43,21 @@ public class CategoryService {
                 .build()));
     }
 
-    public ModifyCategoryResponseDto modifyCategory(ModifyCategoryRequestDto request) {
+    public ModifyCategoryResponseDto modifyCategory(
+            ModifyCategoryRequestDto request
+    ) {
 
         Member member = validateMember(request.getMemberEmail());
 
         Category category = validateCategory(request.getCategoryId());
 
-        forbiddenMember(member, category);
+        requestMemberMismatchCategoryOwner(member, category);
 
         validateUniqueCategoryName(request.getCategoryName());
 
         category.setCategoryName(request.getCategoryName());
         category.setUpdatedAt(LocalDateTime.now());
         categoryRepository.save(category);
-
-        // 기존에 있던 카테고리 수정시 해당 카테고리 가지고 있는 매일지출내역의 정보도 모두 수정하는 로직 추가 예정
-        // 매일 지출내역 main에 머지 후 pull해서 dailypaymentrepository DI 할 예정
 
         return ModifyCategoryResponseDto.of(category);
     }
@@ -69,16 +68,12 @@ public class CategoryService {
 
         Category category = validateCategory(request.getCategoryId());
 
-        forbiddenMember(member, category);
-
-        // 기존에 있던 카테고리 수정시 해당 카테고리 가지고 있는 매일지출내역의 정보도 모두 삭제하는 로직 추가 예정
-        // 매일 지출내역 main에 머지 후 pull해서 dailypaymentrepository DI 할 예정
+        requestMemberMismatchCategoryOwner(member, category);
 
         categoryRepository.deleteById(request.getCategoryId());
     }
 
     public List<GetCategoryListResponseDto> getCategoryList() {
-
         List<Category> all = categoryRepository.findAll();
         return all.stream()
                 .map(category -> GetCategoryListResponseDto.of(category))
@@ -87,30 +82,39 @@ public class CategoryService {
 
     private void validateUniqueCategoryName(String categoryName) {
         if (categoryRepository.existsByCategoryName(categoryName)) {
-            throw new AccountBookException("카테고리 이름이 중복됩니다.", CONFLIC_CATEGORY_NAME_EXCEPTION);
+            throw new AccountBookException(
+                    "카테고리 이름이 중복됩니다.",
+                    CONFLIC_CATEGORY_NAME_EXCEPTION
+            );
         }
     }
 
-    private static void forbiddenMember(Member member, Category category) {
+    private static void requestMemberMismatchCategoryOwner(
+            Member member, Category category
+    ) {
         if (!member.getId().equals(category.getMember().getId())) {
-            throw new AccountBookException("해당 카테고리에는 접근할 수 없습니다. ", FORBIDDEN_EXCEPTION);
+            throw new AccountBookException(
+                    "해당 카테고리에는 접근할 수 없습니다. ",
+                    FORBIDDEN_EXCEPTION
+            );
         }
     }
 
     private Category validateCategory(long categoryId) {
-        Optional<Category> optionalCategory = categoryRepository.findById(categoryId);
-        if (!optionalCategory.isPresent()) {
-            throw new AccountBookException("존재하지 않는 카테고리 입니다.", NOT_FOUND_CATEGORY_EXCEPTION);
-        }
-        return optionalCategory.get();
+        return categoryRepository.findById(categoryId).orElseThrow(
+                () -> new AccountBookException(
+                        "존재하지 않는 카테고리 입니다.",
+                        NOT_FOUND_CATEGORY_EXCEPTION
+                )
+        );
     }
 
     private Member validateMember(String memberEmail) {
-        Optional<Member> optionalMember = memberRepository.findByEmail(memberEmail);
-        if (!optionalMember.isPresent()) {
-            throw new AccountBookException("존재하지 않는 회원입니다.", NOT_FOUND_USER_EXCEPTION);
-        }
-        Member member = optionalMember.get();
-        return member;
+        return memberRepository.findByEmail(memberEmail).orElseThrow(
+                () -> new AccountBookException(
+                        "존재하지 않는 회원입니다.",
+                        NOT_FOUND_USER_EXCEPTION
+                )
+        );
     }
 }

--- a/src/main/java/com/zerobase/accountbook/service/category/CategoryService.java
+++ b/src/main/java/com/zerobase/accountbook/service/category/CategoryService.java
@@ -1,0 +1,12 @@
+package com.zerobase.accountbook.service.category;
+
+import com.zerobase.accountbook.domain.category.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+}

--- a/src/main/java/com/zerobase/accountbook/service/category/CategoryService.java
+++ b/src/main/java/com/zerobase/accountbook/service/category/CategoryService.java
@@ -3,7 +3,9 @@ package com.zerobase.accountbook.service.category;
 import com.zerobase.accountbook.common.exception.ErrorCode;
 import com.zerobase.accountbook.common.exception.model.AccountBookException;
 import com.zerobase.accountbook.controller.category.dto.request.CreateCategoryRequestDto;
+import com.zerobase.accountbook.controller.category.dto.request.ModifyCategoryRequestDto;
 import com.zerobase.accountbook.controller.category.dto.response.CreateCategoryResponseDto;
+import com.zerobase.accountbook.controller.category.dto.response.ModifyCategoryResponseDto;
 import com.zerobase.accountbook.domain.category.Category;
 import com.zerobase.accountbook.domain.category.CategoryRepository;
 import com.zerobase.accountbook.domain.member.Member;
@@ -33,6 +35,38 @@ public class CategoryService {
                 .categoryName(request.getCategoryName())
                 .createdAt(LocalDateTime.now())
                 .build()));
+    }
+
+    public ModifyCategoryResponseDto modifyCategory(ModifyCategoryRequestDto request) {
+
+        Member member = validateMember(request.getMemberEmail());
+
+        Category category = validateCategory(request);
+
+        forbiddenMember(member, category);
+
+        category.setCategoryName(request.getCategoryName());
+        category.setUpdatedAt(LocalDateTime.now());
+        categoryRepository.save(category);
+
+        // 기존에 있던 카테고리 수정시 해당 카테고리 가지고 있는 매일지출내역의 정보도 모두 수정하는 로직 추가 예정
+        // 매일 지출내역 main에 머지 후 pull해서 dailypaymentrepository DI 할 예정
+
+        return ModifyCategoryResponseDto.of(category);
+    }
+
+    private static void forbiddenMember(Member member, Category category) {
+        if (!member.getId().equals(category.getMember().getId())) {
+            throw new AccountBookException("해당 카테고리에는 접근할 수 없습니다. ", FORBIDDEN_EXCEPTION);
+        }
+    }
+
+    private Category validateCategory(ModifyCategoryRequestDto request) {
+        Optional<Category> optionalCategory = categoryRepository.findById(request.getCategoryId());
+        if (!optionalCategory.isPresent()) {
+            throw new AccountBookException("존재하지 않는 카테고리 입니다.", NOT_FOUND_CATEGORY_EXCEPTION);
+        }
+        return optionalCategory.get();
     }
 
     private Member validateMember(String memberEmail) {

--- a/src/main/java/com/zerobase/accountbook/service/category/CategoryService.java
+++ b/src/main/java/com/zerobase/accountbook/service/category/CategoryService.java
@@ -3,6 +3,7 @@ package com.zerobase.accountbook.service.category;
 import com.zerobase.accountbook.common.exception.ErrorCode;
 import com.zerobase.accountbook.common.exception.model.AccountBookException;
 import com.zerobase.accountbook.controller.category.dto.request.CreateCategoryRequestDto;
+import com.zerobase.accountbook.controller.category.dto.request.DeleteCategoryRequestDto;
 import com.zerobase.accountbook.controller.category.dto.request.ModifyCategoryRequestDto;
 import com.zerobase.accountbook.controller.category.dto.response.CreateCategoryResponseDto;
 import com.zerobase.accountbook.controller.category.dto.response.ModifyCategoryResponseDto;
@@ -41,7 +42,7 @@ public class CategoryService {
 
         Member member = validateMember(request.getMemberEmail());
 
-        Category category = validateCategory(request);
+        Category category = validateCategory(request.getCategoryId());
 
         forbiddenMember(member, category);
 
@@ -55,14 +56,28 @@ public class CategoryService {
         return ModifyCategoryResponseDto.of(category);
     }
 
+    public void deleteCategory(DeleteCategoryRequestDto request) {
+
+        Member member = validateMember(request.getMemberEmail());
+
+        Category category = validateCategory(request.getCategoryId());
+
+        forbiddenMember(member, category);
+
+        // 기존에 있던 카테고리 수정시 해당 카테고리 가지고 있는 매일지출내역의 정보도 모두 삭제하는 로직 추가 예정
+        // 매일 지출내역 main에 머지 후 pull해서 dailypaymentrepository DI 할 예정
+
+        categoryRepository.deleteById(request.getCategoryId());
+    }
+
     private static void forbiddenMember(Member member, Category category) {
         if (!member.getId().equals(category.getMember().getId())) {
             throw new AccountBookException("해당 카테고리에는 접근할 수 없습니다. ", FORBIDDEN_EXCEPTION);
         }
     }
 
-    private Category validateCategory(ModifyCategoryRequestDto request) {
-        Optional<Category> optionalCategory = categoryRepository.findById(request.getCategoryId());
+    private Category validateCategory(long categoryId) {
+        Optional<Category> optionalCategory = categoryRepository.findById(categoryId);
         if (!optionalCategory.isPresent()) {
             throw new AccountBookException("존재하지 않는 카테고리 입니다.", NOT_FOUND_CATEGORY_EXCEPTION);
         }

--- a/src/main/java/com/zerobase/accountbook/service/category/CategoryService.java
+++ b/src/main/java/com/zerobase/accountbook/service/category/CategoryService.java
@@ -1,12 +1,46 @@
 package com.zerobase.accountbook.service.category;
 
+import com.zerobase.accountbook.common.exception.ErrorCode;
+import com.zerobase.accountbook.common.exception.model.AccountBookException;
+import com.zerobase.accountbook.controller.category.dto.request.CreateCategoryRequestDto;
+import com.zerobase.accountbook.controller.category.dto.response.CreateCategoryResponseDto;
+import com.zerobase.accountbook.domain.category.Category;
 import com.zerobase.accountbook.domain.category.CategoryRepository;
+import com.zerobase.accountbook.domain.member.Member;
+import com.zerobase.accountbook.domain.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static com.zerobase.accountbook.common.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
 public class CategoryService {
 
     private final CategoryRepository categoryRepository;
+
+    private final MemberRepository memberRepository;
+
+    public CreateCategoryResponseDto createCategory(CreateCategoryRequestDto request) {
+
+        Member member = validateMember(request.getMemberEmail());
+
+        return CreateCategoryResponseDto.of(categoryRepository.save(Category.builder()
+                .member(member)
+                .categoryName(request.getCategoryName())
+                .createdAt(LocalDateTime.now())
+                .build()));
+    }
+
+    private Member validateMember(String memberEmail) {
+        Optional<Member> optionalMember = memberRepository.findByEmail(memberEmail);
+        if (!optionalMember.isPresent()) {
+            throw new AccountBookException("존재하지 않는 회원입니다.", NOT_FOUND_USER_EXCEPTION);
+        }
+        Member member = optionalMember.get();
+        return member;
+    }
 }

--- a/src/main/java/com/zerobase/accountbook/service/category/CategoryService.java
+++ b/src/main/java/com/zerobase/accountbook/service/category/CategoryService.java
@@ -6,6 +6,7 @@ import com.zerobase.accountbook.controller.category.dto.request.CreateCategoryRe
 import com.zerobase.accountbook.controller.category.dto.request.DeleteCategoryRequestDto;
 import com.zerobase.accountbook.controller.category.dto.request.ModifyCategoryRequestDto;
 import com.zerobase.accountbook.controller.category.dto.response.CreateCategoryResponseDto;
+import com.zerobase.accountbook.controller.category.dto.response.GetCategoryListResponseDto;
 import com.zerobase.accountbook.controller.category.dto.response.ModifyCategoryResponseDto;
 import com.zerobase.accountbook.domain.category.Category;
 import com.zerobase.accountbook.domain.category.CategoryRepository;
@@ -15,7 +16,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.zerobase.accountbook.common.exception.ErrorCode.*;
 
@@ -68,6 +71,14 @@ public class CategoryService {
         // 매일 지출내역 main에 머지 후 pull해서 dailypaymentrepository DI 할 예정
 
         categoryRepository.deleteById(request.getCategoryId());
+    }
+
+    public List<GetCategoryListResponseDto> getCategoryList() {
+
+        List<Category> all = categoryRepository.findAll();
+        return all.stream()
+                .map(category -> GetCategoryListResponseDto.of(category))
+                .collect(Collectors.toList());
     }
 
     private static void forbiddenMember(Member member, Category category) {


### PR DESCRIPTION
### 📍 변경사항
RESTful API 규칙을 반영해 URL 경로를 수정했습니다.
가독성을 높이기 위해 메서드명과 구현내용을 수정했습니다. 

### 📍 AS - IS
1. 공통 응답 처리 
성공시 statusCode, message, data 를 Json 형태로 응답합니다.
<img width="737" alt="스크린샷 2023-01-12 오후 3 49 26" src="https://user-images.githubusercontent.com/81020108/211997288-a7ce7df6-36af-4c28-a4bf-aae87d485119.png">


실패시 statusCode, message 를 Json 형태로 응답해 어떤 문제인지 구체적으로 알려줍니다.
<img width="737" alt="스크린샷 2023-01-12 오후 3 49 36" src="https://user-images.githubusercontent.com/81020108/211997297-1f2e72a7-a4dd-485b-b5b3-939f31906fd0.png">

2. 로그인한 유저만 사용가능
로그인 성공한 유저만 해당 기능에 접근 가능합니다. 

3. 카테고리 생성
*  사용자 이메일과 카테고리명을 클라이언트로부터 전달받습니다.
*  중복된 카테고리명은 불가능합니다.
*  사용자 검증 후 카테고리를 DB에 저장합니다.

4.  카테고리 수정
* 사용자 이메일, 카테고리 아이디, 변경할 카테고리명을 클라이언트로부터 전달받습니다.
* 중복된 카테고리명은 불가능합니다.
* 사용자 검증 후 카테고리의 정보를 변경합니다.

5. 카테고리 삭제 
* 사용자 이메일, 삭제할 카테고리의 아이디를 클라이언트로부터 전달받습니다.
* 사용자 검증 후 카테고리의 정보를 삭제합니다.

6.  카테고리 목록 조회
* 전체 카테고리들의 정보를 가져와 사용자에게 보여줍니다. 


### 📍 TO - BE
- [ ] 카테고리 이름 수정시 관련된 매일지출내역의 카테고리명도 수정하는 로직 추가
       해당 부분은 매일지출내역과 머지한 뒤 진행할 수 있을 것 같아 4주차에 할 에정입니다. 
- [ ] 로그인 사용자 정보 가져오는 로직 추가
- [ ] 서비스 클래스 테스트 

### 📍 테스트
- [x] API Test
- [ ]  단위 테스트