### PR TITLE
[4주차 PR] Issue#7 키워드로 지출내역과 메모 검색 기능 구현

### DIFF
--- a/src/main/java/com/zerobase/accountbook/controller/dailypayments/DailyPaymentsController.java
+++ b/src/main/java/com/zerobase/accountbook/controller/dailypayments/DailyPaymentsController.java
@@ -4,6 +4,7 @@ import com.zerobase.accountbook.common.dto.ApiResponse;
 import com.zerobase.accountbook.controller.dailypayments.dto.request.CreateDailyPaymentsRequestDto;
 import com.zerobase.accountbook.controller.dailypayments.dto.request.ModifyDailyPaymentsRequestDto;
 import com.zerobase.accountbook.controller.dailypayments.dto.response.CreateDailyPaymentsResponseDto;
+import com.zerobase.accountbook.controller.dailypayments.dto.response.SearchDailyPaymentsResponseDto;
 import com.zerobase.accountbook.controller.dailypayments.dto.response.GetDailyPaymentsResponseDto;
 import com.zerobase.accountbook.controller.dailypayments.dto.response.ModifyDailyPaymentsResponseDto;
 import com.zerobase.accountbook.controller.dailypayments.dto.request.DeleteDailyPaymentsRequestDto;
@@ -25,10 +26,11 @@ public class DailyPaymentsController {
 
     @PostMapping()
     public ApiResponse<CreateDailyPaymentsResponseDto> createDailyPayments(
+            @AuthenticationPrincipal UserDetails user,
             @Valid @RequestBody CreateDailyPaymentsRequestDto request
     ) {
         CreateDailyPaymentsResponseDto response =
-                dailyPaymentsService.createDailyPayments(request);
+                dailyPaymentsService.createDailyPayments(user.getUsername(), request);
         return ApiResponse.success(response);
     }
 
@@ -61,6 +63,19 @@ public class DailyPaymentsController {
     public ApiResponse<List<GetDailyPaymentsResponseDto>> getDailyPaymentsList() {
         List<GetDailyPaymentsResponseDto> response =
                 dailyPaymentsService.getDailyPaymentsList();
+        return ApiResponse.success(response);
+    }
+
+    @GetMapping("/search")
+    public ApiResponse<List<SearchDailyPaymentsResponseDto>> searchDailyPayments(
+            @AuthenticationPrincipal UserDetails user,
+            @RequestParam String keyword
+    ) {
+        List<SearchDailyPaymentsResponseDto> response =
+                dailyPaymentsService.searchDailyPayments(
+                        user.getUsername(),
+                        keyword
+                );
         return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/zerobase/accountbook/controller/dailypayments/DailyPaymentsController.java
+++ b/src/main/java/com/zerobase/accountbook/controller/dailypayments/DailyPaymentsController.java
@@ -30,39 +30,53 @@ public class DailyPaymentsController {
             @Valid @RequestBody CreateDailyPaymentsRequestDto request
     ) {
         CreateDailyPaymentsResponseDto response =
-                dailyPaymentsService.createDailyPayments(user.getUsername(), request);
+                dailyPaymentsService.createDailyPayments(
+                        user.getUsername(),
+                        request
+                );
         return ApiResponse.success(response);
     }
 
     @PutMapping()
     public ApiResponse<ModifyDailyPaymentsResponseDto> modifyDailyPayments(
+            @AuthenticationPrincipal UserDetails user,
             @Valid @RequestBody ModifyDailyPaymentsRequestDto request
     ) {
         ModifyDailyPaymentsResponseDto response =
-                dailyPaymentsService.modifyDailyPayments(request);
+                dailyPaymentsService.modifyDailyPayments(
+                        user.getUsername(),
+                        request
+                );
         return ApiResponse.success(response);
     }
 
     @DeleteMapping()
     public void deleteDailyPayments(
+            @AuthenticationPrincipal UserDetails user,
             @Valid @RequestBody DeleteDailyPaymentsRequestDto request
     ) {
-        dailyPaymentsService.deleteDailyPayments(request);
+        dailyPaymentsService.deleteDailyPayments(user.getUsername(), request);
     }
 
     @GetMapping("/{dailyPaymentsId}")
     public ApiResponse<GetDailyPaymentsResponseDto> getDailyPayments(
+            @AuthenticationPrincipal UserDetails user,
             @PathVariable Long dailyPaymentsId
     ) {
         GetDailyPaymentsResponseDto response =
-                dailyPaymentsService.getDailyPayments(dailyPaymentsId);
+                dailyPaymentsService.getDailyPayments(
+                        user.getUsername(),
+                        dailyPaymentsId
+                );
         return ApiResponse.success(response);
     }
 
     @GetMapping("/list")
-    public ApiResponse<List<GetDailyPaymentsResponseDto>> getDailyPaymentsList() {
+    public ApiResponse<List<GetDailyPaymentsResponseDto>> getDailyPaymentsList(
+            @AuthenticationPrincipal UserDetails user
+    ) {
         List<GetDailyPaymentsResponseDto> response =
-                dailyPaymentsService.getDailyPaymentsList();
+                dailyPaymentsService.getDailyPaymentsList(user.getUsername());
         return ApiResponse.success(response);
     }
 

--- a/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/request/CreateDailyPaymentsRequestDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/request/CreateDailyPaymentsRequestDto.java
@@ -13,9 +13,6 @@ import javax.validation.constraints.Size;
 @AllArgsConstructor
 public class CreateDailyPaymentsRequestDto {
 
-    @Email
-    private String memberEmail;
-
     @Min(0)
     private Integer paidAmount;
 
@@ -26,6 +23,6 @@ public class CreateDailyPaymentsRequestDto {
 
     private String categoryName;
 
-    @Size(max = 30, message = "해시태그의 총 30자가 넘어서는 안됩니다.")
-    private String hashTags; // "#abc, #dbe, #acds" 형태로 전달 받음
+    @Size(max = 30, message = "메모의 길이는 최대 30자입니다.")
+    private String memo;
 }

--- a/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/request/DeleteDailyPaymentsRequestDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/request/DeleteDailyPaymentsRequestDto.java
@@ -11,8 +11,5 @@ import javax.validation.constraints.Email;
 @AllArgsConstructor
 public class DeleteDailyPaymentsRequestDto {
 
-    @Email
-    private String memberEmail;
-
     private Long dailyPaymentsId;
 }

--- a/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/request/ModifyDailyPaymentsRequestDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/request/ModifyDailyPaymentsRequestDto.java
@@ -31,8 +31,8 @@ public class ModifyDailyPaymentsRequestDto {
 
     private String categoryName;
 
-    @Size(max = 30, message = "해시태그의 총 길이는 30자가 넘어서는 안됩니다.")
-    private String hashTags; // "#abc, #dbe, #acds" 형태로 전달 받음
+    @Size(max = 30, message = "메모의 길이는 최대 30자입니다.")
+    private String memo;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
     private String createdAt;

--- a/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/request/ModifyDailyPaymentsRequestDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/request/ModifyDailyPaymentsRequestDto.java
@@ -18,9 +18,6 @@ public class ModifyDailyPaymentsRequestDto {
 
     private long dailyPaymentsId;
 
-    @Email
-    private String memberEmail;
-
     @Min(0)
     private Integer paidAmount;
 

--- a/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/response/GetDailyPaymentsResponseDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/response/GetDailyPaymentsResponseDto.java
@@ -18,7 +18,7 @@ public class GetDailyPaymentsResponseDto {
 
     private String categoryName;
 
-    private String hashTag;
+    private String memo;
 
     public static GetDailyPaymentsResponseDto of(DailyPayments dailyPayments) {
         return GetDailyPaymentsResponseDto
@@ -27,7 +27,7 @@ public class GetDailyPaymentsResponseDto {
                 .paidWhere(dailyPayments.getPaidWhere())
                 .methodOfPayment(dailyPayments.getMethodOfPayment())
                 .categoryName(dailyPayments.getCategoryName())
-                .hashTag(dailyPayments.getHashTag())  // 추후에 변경 예정
+                .memo(dailyPayments.getMemo())
                 .build();
     }
 }

--- a/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/response/ModifyDailyPaymentsResponseDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/response/ModifyDailyPaymentsResponseDto.java
@@ -20,7 +20,7 @@ public class ModifyDailyPaymentsResponseDto {
 
     private String categoryName;
 
-    private String hashTags;
+    private String memo;
 
     private String updatedAt;
 
@@ -32,6 +32,7 @@ public class ModifyDailyPaymentsResponseDto {
                 .paidWhere(dailyPayments.getPaidWhere())
                 .methodOfPayment(dailyPayments.getMethodOfPayment())
                 .categoryName(dailyPayments.getCategoryName())
+                .memo(dailyPayments.getMemo())
                 .updatedAt(dailyPayments.getUpdatedAt())
                 .build();
     }

--- a/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/response/SearchDailyPaymentsResponseDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/response/SearchDailyPaymentsResponseDto.java
@@ -8,11 +8,9 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CreateDailyPaymentsResponseDto {
+public class SearchDailyPaymentsResponseDto {
 
-    private Long dailyPaymentsId;
-
-    private Integer paidAmount;
+    private long dailyPaymentsId;
 
     private String paidWhere;
 
@@ -20,19 +18,33 @@ public class CreateDailyPaymentsResponseDto {
 
     private String methodOfPayment;
 
+    private Integer paidAmount;
+
     private String memo;
 
     private String createdAt;
 
-    public static CreateDailyPaymentsResponseDto of(DailyPayments dailyPayments) {
-        return CreateDailyPaymentsResponseDto.builder()
+    private String updatedAt;
+
+    public static SearchDailyPaymentsResponseDto of(
+            DailyPayments dailyPayments
+    ) {
+        return SearchDailyPaymentsResponseDto.builder()
                 .dailyPaymentsId(dailyPayments.getId())
-                .paidAmount(dailyPayments.getPaidAmount())
                 .paidWhere(dailyPayments.getPaidWhere())
                 .categoryName(dailyPayments.getCategoryName())
                 .methodOfPayment(dailyPayments.getMethodOfPayment())
+                .paidAmount(dailyPayments.getPaidAmount())
                 .memo(dailyPayments.getMemo())
-                .createdAt(dailyPayments.getCreatedAt())
+                .createdAt(convertDateToYearAndMonth(dailyPayments.getCreatedAt()))
+                .updatedAt(convertDateToYearAndMonth(dailyPayments.getUpdatedAt()))
                 .build();
+    }
+
+    private static String convertDateToYearAndMonth(String date) {
+        if (date == null) {
+            return "";
+        }
+        return date.substring(0, 10);
     }
 }

--- a/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPayments.java
+++ b/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPayments.java
@@ -33,7 +33,7 @@ public class DailyPayments {
 
     private String categoryName;
 
-    private String hashTag;
+    private String memo;
 
     @CreatedDate
     private String createdAt;

--- a/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPaymentsRepository.java
+++ b/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPaymentsRepository.java
@@ -1,6 +1,19 @@
 package com.zerobase.accountbook.domain.dailypayments;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface DailyPaymentsRepository extends JpaRepository<DailyPayments, Long> {
+
+    @Query(
+            nativeQuery = true,
+            value = "select * " +
+                    "from daily_payments dp " +
+                    "where dp.member_id = :memberId " +
+                    "and (dp.paid_where like %:keyword% " +
+                    "or dp.memo like %:keyword%)"
+    )
+    List<DailyPayments> searchKeyword(long memberId, String keyword);
 }

--- a/src/main/java/com/zerobase/accountbook/service/dailypaymetns/DailyPaymentsService.java
+++ b/src/main/java/com/zerobase/accountbook/service/dailypaymetns/DailyPaymentsService.java
@@ -54,15 +54,16 @@ public class DailyPaymentsService {
 
     @CachePut(value = "dailyPayments", key = "#request.dailyPaymentsId")
     public ModifyDailyPaymentsResponseDto modifyDailyPayments(
+            String memberEmail,
             ModifyDailyPaymentsRequestDto request
     ) {
 
-        Member member = validateMember(request.getMemberEmail());
+        Member member = validateMember(memberEmail);
         DailyPayments dailyPayments =
                 validateDailyPayments(request.getDailyPaymentsId());
 
         // 지출내역의 주인과 수정하려는 사용자가 다를 경우
-        requestMemberAndDailyPaymentsOwnerMismatch(member, dailyPayments);
+        checkDailyPaymentsOwner(member, dailyPayments);
 
         dailyPayments.setPaidAmount(request.getPaidAmount());
         dailyPayments.setPaidWhere(request.getPaidWhere());
@@ -77,28 +78,40 @@ public class DailyPaymentsService {
     }
 
     @CacheEvict(value = "dailyPayments", allEntries = true)
-    public void deleteDailyPayments(DeleteDailyPaymentsRequestDto request) {
+    public void deleteDailyPayments(
+            String memberEmail, DeleteDailyPaymentsRequestDto request
+    ) {
+        Member member = validateMember(memberEmail);
 
-        Member member = validateMember(request.getMemberEmail());
+        DailyPayments dailyPayments =
+                validateDailyPayments(request.getDailyPaymentsId());
 
-        DailyPayments dailyPayments = validateDailyPayments(request.getDailyPaymentsId());
-
-        requestMemberAndDailyPaymentsOwnerMismatch(member, dailyPayments);
+        checkDailyPaymentsOwner(member, dailyPayments);
 
         dailyPaymentsRepository.delete(dailyPayments);
     }
 
     @Transactional(readOnly = true)
-    public GetDailyPaymentsResponseDto getDailyPayments(Long dailyPaymentsId) {
+    public GetDailyPaymentsResponseDto getDailyPayments(
+            String memberEmail, Long dailyPaymentsId
+    ) {
+
+        Member member = validateMember(memberEmail);
 
         DailyPayments dailyPayments = validateDailyPayments(dailyPaymentsId);
+
+        checkDailyPaymentsOwner(member, dailyPayments);
 
         return GetDailyPaymentsResponseDto.of(dailyPayments);
     }
 
     @Transactional(readOnly = true)
     @Cacheable("dailyPayments")
-    public List<GetDailyPaymentsResponseDto> getDailyPaymentsList() {
+    public List<GetDailyPaymentsResponseDto> getDailyPaymentsList(
+            String memberEmail
+    ) {
+        validateMember(memberEmail);
+
         List<DailyPayments> all = dailyPaymentsRepository.findAll();
 
         return all.stream()
@@ -119,7 +132,7 @@ public class DailyPaymentsService {
                 .collect(Collectors.toList());
     }
 
-    private static void requestMemberAndDailyPaymentsOwnerMismatch(
+    private static void checkDailyPaymentsOwner(
             Member member, DailyPayments dailyPayments
     ) {
         if (!dailyPayments.getMember().getId().equals(member.getId())) {
@@ -153,7 +166,7 @@ public class DailyPaymentsService {
     private Member validateMember(String memberEmail) {
         return memberRepository.findByEmail(memberEmail).orElseThrow(
                 () -> new AccountBookException(
-                        "존재하지 않는 화면입니다.",
+                        "존재하지 않는 회원입니다.",
                         NOT_FOUND_USER_EXCEPTION
                 )
         );


### PR DESCRIPTION
### 📍 변경사항
원래는 해시태그 검색을 구현하려했으나, 과제 마감까지 시간이 많지 않아 메모를 검색하는 것으로 변경했습니다.
(추후에 해시태그와 Elastic Search로 기능 구현을 진행할 생각입니다.)

### 📍 AS - IS

1. 공통 
* 로그인한 사용자만 이용할 수 있습니다.
* 계정주만 사용할 수 있습니다. 
* statusCode, message, data를 Json 형식으로 응답합니다.

2. 검색 기능 
* 사용자가 검색한 키워드를 URL 쿼리스트링에 입력합니다.
* 키워드가 포함된 지출 장소 또는 메모를 가진 매일 지출내역을 조회합니다.
* 결과를 리스트로 응답합니다.

### 📍 TO - BE
- [ ] 매일 지출내역에 해시태그 기능 추가 
- [ ] Elastic Search 공부 후 적용 

### 📍 테스트
- [x] API Test
- [ ]  단위 테스트