### PR TITLE
[4주차 PR] Issue#12 한달 총 지출내역 카테고리별로 조회하는 기능 구현

### DIFF
--- a/src/main/java/com/zerobase/accountbook/common/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/accountbook/common/exception/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
     NOT_FOUND_DAILY_PAYMENTS_EXCEPTION(NOT_FOUND, "가입되지 않은 이메일입니다."),
 
     NOT_FOUND_CATEGORY_EXCEPTION(NOT_FOUND, "존재하지 않는 카테고리입니다."),
+    NOT_FOUND_MONTHLY_TOTAL_AMOUNT_EXCEPTION(NOT_FOUND, "총 지출이 존재하지 않습니다."),
 
 
     // 405 Method Not Allowed

--- a/src/main/java/com/zerobase/accountbook/controller/dailypayments/DailyPaymentsController.java
+++ b/src/main/java/com/zerobase/accountbook/controller/dailypayments/DailyPaymentsController.java
@@ -3,10 +3,7 @@ package com.zerobase.accountbook.controller.dailypayments;
 import com.zerobase.accountbook.common.dto.ApiResponse;
 import com.zerobase.accountbook.controller.dailypayments.dto.request.CreateDailyPaymentsRequestDto;
 import com.zerobase.accountbook.controller.dailypayments.dto.request.ModifyDailyPaymentsRequestDto;
-import com.zerobase.accountbook.controller.dailypayments.dto.response.CreateDailyPaymentsResponseDto;
-import com.zerobase.accountbook.controller.dailypayments.dto.response.SearchDailyPaymentsResponseDto;
-import com.zerobase.accountbook.controller.dailypayments.dto.response.GetDailyPaymentsResponseDto;
-import com.zerobase.accountbook.controller.dailypayments.dto.response.ModifyDailyPaymentsResponseDto;
+import com.zerobase.accountbook.controller.dailypayments.dto.response.*;
 import com.zerobase.accountbook.controller.dailypayments.dto.request.DeleteDailyPaymentsRequestDto;
 import com.zerobase.accountbook.service.dailypaymetns.DailyPaymentsService;
 import lombok.RequiredArgsConstructor;
@@ -89,6 +86,20 @@ public class DailyPaymentsController {
                 dailyPaymentsService.searchDailyPayments(
                         user.getUsername(),
                         keyword
+                );
+        return ApiResponse.success(response);
+    }
+
+    @GetMapping("/monthly/{date}")
+    public ApiResponse<GetMonthlyResultResponseDto>
+    getMonthlyResultResponseDto(
+            @AuthenticationPrincipal UserDetails user,
+            @PathVariable String date
+    ) {
+        GetMonthlyResultResponseDto response =
+                dailyPaymentsService.getMonthlyDailyPaymentsResult(
+                        user.getUsername(),
+                        date
                 );
         return ApiResponse.success(response);
     }

--- a/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/response/GetMonthlyResultResponseDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/response/GetMonthlyResultResponseDto.java
@@ -1,0 +1,49 @@
+package com.zerobase.accountbook.controller.dailypayments.dto.response;
+
+import com.zerobase.accountbook.domain.totalamountpercategory.TotalAmountPerCategory;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Setter
+@Getter
+public class GetMonthlyResultResponseDto {
+
+    private Integer totalAmount;
+
+    private List<MonthlyResultDto> list;
+
+    public static GetMonthlyResultResponseDto of (
+            Integer totalAmount, HashMap<String, Integer> hashMap
+    ) {
+        List<MonthlyResultDto> list = new ArrayList<>();
+        for (String key : hashMap.keySet()) {
+            list.add(MonthlyResultDto.of(key, hashMap.get(key)));
+        }
+        return GetMonthlyResultResponseDto.builder()
+                .totalAmount(totalAmount)
+                .list(list)
+                .build();
+    }
+
+    public static GetMonthlyResultResponseDto of (
+            Integer totalAmount, List<TotalAmountPerCategory> all
+    ) {
+        List<MonthlyResultDto> list = new ArrayList<>();
+        for (TotalAmountPerCategory each : all) {
+            list.add(MonthlyResultDto.of(
+                    each.getCategoryName(),
+                    each.getTotalAmount()
+            ));
+        }
+        return GetMonthlyResultResponseDto.builder()
+                .totalAmount(totalAmount)
+                .list(list)
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/response/MonthlyResultDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/response/MonthlyResultDto.java
@@ -1,0 +1,22 @@
+package com.zerobase.accountbook.controller.dailypayments.dto.response;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Setter
+@Getter
+public class MonthlyResultDto {
+
+    private String categoryName;
+
+    private Integer totalAmount;
+
+    public static MonthlyResultDto of(String key, Integer value) {
+        return MonthlyResultDto.builder()
+                .categoryName(key)
+                .totalAmount(value)
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPaymentsRepository.java
+++ b/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPaymentsRepository.java
@@ -18,4 +18,6 @@ public interface DailyPaymentsRepository extends JpaRepository<DailyPayments, Lo
     List<DailyPayments> searchKeyword(long memberId, String keyword);
 
     List<DailyPayments> findByCreatedAtBetween(String before, String now);
+
+    List<DailyPayments> findByMemberIdAndCreatedAtBetween(Long memberId, String before, String now);
 }

--- a/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPaymentsRepository.java
+++ b/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPaymentsRepository.java
@@ -20,4 +20,6 @@ public interface DailyPaymentsRepository extends JpaRepository<DailyPayments, Lo
     List<DailyPayments> findByCreatedAtBetween(String before, String now);
 
     List<DailyPayments> findByMemberIdAndCreatedAtBetween(Long memberId, String before, String now);
+
+    List<DailyPayments> findByMemberIdAndCreatedAtContaining(Long memberId, String createdAt);
 }

--- a/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPaymentsRepository.java
+++ b/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPaymentsRepository.java
@@ -16,4 +16,6 @@ public interface DailyPaymentsRepository extends JpaRepository<DailyPayments, Lo
                     "or dp.memo like %:keyword%)"
     )
     List<DailyPayments> searchKeyword(long memberId, String keyword);
+
+    List<DailyPayments> findByCreatedAtBetween(String before, String now);
 }

--- a/src/main/java/com/zerobase/accountbook/domain/monthlytotalamount/MonthlyTotalAmount.java
+++ b/src/main/java/com/zerobase/accountbook/domain/monthlytotalamount/MonthlyTotalAmount.java
@@ -1,0 +1,36 @@
+package com.zerobase.accountbook.domain.monthlytotalamount;
+
+import com.zerobase.accountbook.domain.member.Member;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Setter
+@Getter
+@Entity
+public class MonthlyTotalAmount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "MEMBER_ID")
+    private Member member;
+
+    private String dateInfo;
+
+    private Integer totalAmount;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/zerobase/accountbook/domain/monthlytotalamount/MonthlyTotalAmountRepository.java
+++ b/src/main/java/com/zerobase/accountbook/domain/monthlytotalamount/MonthlyTotalAmountRepository.java
@@ -1,0 +1,11 @@
+package com.zerobase.accountbook.domain.monthlytotalamount;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+
+public interface MonthlyTotalAmountRepository extends JpaRepository<MonthlyTotalAmount, Long> {
+
+    Optional<MonthlyTotalAmount> findByDateInfoAndMemberId(String dateInfo, Long memberId);
+}

--- a/src/main/java/com/zerobase/accountbook/domain/totalamountpercategory/TotalAmountPerCategory.java
+++ b/src/main/java/com/zerobase/accountbook/domain/totalamountpercategory/TotalAmountPerCategory.java
@@ -1,0 +1,38 @@
+package com.zerobase.accountbook.domain.totalamountpercategory;
+
+import com.zerobase.accountbook.domain.member.Member;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Setter
+@Getter
+@Entity
+public class TotalAmountPerCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne()
+    @JoinColumn(name = "MEMBER_ID")
+    private Member member;
+
+    private String dateInfo;
+
+    private String categoryName;
+
+    private Integer totalAmount;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/zerobase/accountbook/domain/totalamountpercategory/TotalAmountPerCategoryRepository.java
+++ b/src/main/java/com/zerobase/accountbook/domain/totalamountpercategory/TotalAmountPerCategoryRepository.java
@@ -1,0 +1,10 @@
+package com.zerobase.accountbook.domain.totalamountpercategory;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TotalAmountPerCategoryRepository extends JpaRepository<TotalAmountPerCategory, Long> {
+
+    List<TotalAmountPerCategory> findByDateInfoAndMemberId(String dateInfo, Long memberId);
+}

--- a/src/main/java/com/zerobase/accountbook/service/monthlytotalamount/MonthlyTotalAmountService.java
+++ b/src/main/java/com/zerobase/accountbook/service/monthlytotalamount/MonthlyTotalAmountService.java
@@ -26,7 +26,7 @@ public class MonthlyTotalAmountService {
 
 
     @Scheduled(cron = "0 0 0 1 * * *") // 매달 1일 정각에 모든 사용자에 대해 실행
-    private MonthlyTotalAmount saveMonthlyTotalAmount() {
+    private void saveMonthlyTotalAmount() {
 
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime oneMonthBefore = now.minusMonths(1);
@@ -50,14 +50,13 @@ public class MonthlyTotalAmountService {
 
             Member member = validateMember(memberEmail);
 
-            return monthlyTotalAmountRepository.save(MonthlyTotalAmount.builder()
+            monthlyTotalAmountRepository.save(MonthlyTotalAmount.builder()
                     .dateInfo(oneMonthBefore.toString().substring(0, 7)) // 2023-01 형태로 저장
                     .member(member)
                     .totalAmount(memberSum)
                     .createdAt(now)
                     .build());
         }
-        return null;
     }
 
     private Member validateMember(String memberEmail) {

--- a/src/main/java/com/zerobase/accountbook/service/monthlytotalamount/MonthlyTotalAmountService.java
+++ b/src/main/java/com/zerobase/accountbook/service/monthlytotalamount/MonthlyTotalAmountService.java
@@ -1,0 +1,71 @@
+package com.zerobase.accountbook.service.monthlytotalamount;
+
+import com.zerobase.accountbook.common.exception.model.AccountBookException;
+import com.zerobase.accountbook.domain.dailypayments.DailyPayments;
+import com.zerobase.accountbook.domain.dailypayments.DailyPaymentsRepository;
+import com.zerobase.accountbook.domain.member.Member;
+import com.zerobase.accountbook.domain.member.MemberRepository;
+import com.zerobase.accountbook.domain.monthlytotalamount.MonthlyTotalAmount;
+import com.zerobase.accountbook.domain.monthlytotalamount.MonthlyTotalAmountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.zerobase.accountbook.common.exception.ErrorCode.NOT_FOUND_USER_EXCEPTION;
+
+@Service
+@RequiredArgsConstructor
+public class MonthlyTotalAmountService {
+
+    private final MemberRepository memberRepository;
+    private final DailyPaymentsRepository dailyPaymentsRepository;
+    private final MonthlyTotalAmountRepository monthlyTotalAmountRepository;
+
+
+    @Scheduled(cron = "0 0 0 1 * * *") // 매달 1일 정각에 모든 사용자에 대해 실행
+    private MonthlyTotalAmount saveMonthlyTotalAmount() {
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime oneMonthBefore = now.minusMonths(1);
+
+        List<DailyPayments> all =
+                dailyPaymentsRepository.findByCreatedAtBetween(
+                        oneMonthBefore.toString(),
+                        now.toString()
+                );
+
+        // 회원 정보를 가져올 수 없어서 매일 지출내역 전체를 탐색하며 회원 정보 가져오기
+        List<Member> members = memberRepository.findAll();
+        for (Member each : members) {
+            Integer memberSum = 0;
+            String memberEmail = each.getEmail();
+            for (DailyPayments dailyPayments : all) {
+                if (memberEmail.equals(dailyPayments.getMember().getEmail())) {
+                    memberSum += dailyPayments.getPaidAmount();
+                }
+            }
+
+            Member member = validateMember(memberEmail);
+
+            return monthlyTotalAmountRepository.save(MonthlyTotalAmount.builder()
+                    .dateInfo(oneMonthBefore.toString().substring(0, 7)) // 2023-01 형태로 저장
+                    .member(member)
+                    .totalAmount(memberSum)
+                    .createdAt(now)
+                    .build());
+        }
+        return null;
+    }
+
+    private Member validateMember(String memberEmail) {
+        return memberRepository.findByEmail(memberEmail).orElseThrow(
+                () -> new AccountBookException(
+                        "존재하지 않는 회원입니다.",
+                        NOT_FOUND_USER_EXCEPTION
+                )
+        );
+    }
+}

--- a/src/main/java/com/zerobase/accountbook/service/totalamountpercategory/TotalAmountPerCategoryService.java
+++ b/src/main/java/com/zerobase/accountbook/service/totalamountpercategory/TotalAmountPerCategoryService.java
@@ -1,0 +1,80 @@
+package com.zerobase.accountbook.service.totalamountpercategory;
+
+import com.zerobase.accountbook.common.exception.model.AccountBookException;
+import com.zerobase.accountbook.domain.dailypayments.DailyPayments;
+import com.zerobase.accountbook.domain.dailypayments.DailyPaymentsRepository;
+import com.zerobase.accountbook.domain.member.Member;
+import com.zerobase.accountbook.domain.member.MemberRepository;
+import com.zerobase.accountbook.domain.totalamountpercategory.TotalAmountPerCategory;
+import com.zerobase.accountbook.domain.totalamountpercategory.TotalAmountPerCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+
+import static com.zerobase.accountbook.common.exception.ErrorCode.NOT_FOUND_USER_EXCEPTION;
+
+@Service
+@RequiredArgsConstructor
+public class TotalAmountPerCategoryService {
+
+    private final MemberRepository memberRepository;
+
+    private final DailyPaymentsRepository dailyPaymentsRepository;
+
+    private final TotalAmountPerCategoryRepository totalAmountPerCategoryRepository;
+
+    @Scheduled(cron = "0 0 0 1 * * *") // 매달 1일 정각에 모든 사용자에 대해 실행
+    private void saveMoneyPerCategory() {
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime oneMonthBefore = now.minusMonths(1);
+
+        List<Member> members = memberRepository.findAll();
+        HashMap<String, Integer> totalAmountPerCategory = new HashMap<>();
+        for (Member each : members) {
+            Long memberId = each.getId();
+
+            List<DailyPayments> all =
+                    dailyPaymentsRepository.findByMemberIdAndCreatedAtBetween(
+                            memberId,
+                            oneMonthBefore.toString(),
+                            now.toString()
+                    );
+
+            for (DailyPayments dailyPayments : all) {
+                String categoryName = dailyPayments.getCategoryName();
+                Integer paidAmount = dailyPayments.getPaidAmount();
+
+                totalAmountPerCategory.put(
+                        categoryName,
+                        totalAmountPerCategory.getOrDefault(categoryName, 0)
+                                + paidAmount);
+            }
+
+            Member member = validateMemberById(memberId);
+
+            for (String key : totalAmountPerCategory.keySet()) {
+                totalAmountPerCategoryRepository.save(TotalAmountPerCategory.builder()
+                        .member(member)
+                        .dateInfo(String.valueOf(oneMonthBefore).substring(0, 7)) // 2023-01 형태로 저장
+                        .categoryName(key)
+                        .totalAmount(totalAmountPerCategory.get(key))
+                        .createdAt(LocalDateTime.now())
+                        .build());
+            }
+        }
+    }
+
+    private Member validateMemberById(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(
+                () -> new AccountBookException(
+                        "존재하지 않는 회원입니다.",
+                        NOT_FOUND_USER_EXCEPTION
+                )
+        );
+    }
+}


### PR DESCRIPTION
### 📍 변경사항
한달 동안의 지출내역을 카테고리별로 분류하는 기능을 구현했습니다. 
총 지출내역 테이블만 추가하려 했으나, 카테고리별 총 금액도 저장하는 테이블도 추가했습니다.

### 📍 AS - IS

1. 공통 
* 로그인한 사용자만 이용할 수 있습니다.
* 계정주만 사용할 수 있습니다. 
* statusCode, message, data를 Json 형식으로 응답합니다.


2. 매달 1일 자정에 스프링 배치를 이용해서 지출내역 저장 기능
* 사용자들의 이전 월 총 지출금액을 저장합니다.
* 사용자들의 이전 달 지출 금액을 카테고리 별로 분류한 뒤 저장합니다. 


3. 한달 지출내역 통계 조회
* 이번달을 조회할 때는 현재 년월 정보("yyyy-MM")를 가지고 조회한 결과를 응답합니다.
* 지난달을 조회할 때는 위의 2번 과정에서 저장했던 총 지출금액과 카테고리별 금액을 기간("yyyy-MM")과 사용자로 조회한 뒤 해당 정보로 응답합니다. 

### 📍 TO - BE
- [ ] 매일 지출내역의 시간 형식 통일
- [ ] 필요없는 코드 수정 

### 📍 테스트
- [x] API Test
- [ ]  단위 테스트