### PR TITLE
[test] issue#4 DailyPaymentsService CRUD 테스트 코드 작성

### DIFF
--- a/src/main/java/com/zerobase/accountbook/controller/dailypayments/DailyPaymentsController.java
+++ b/src/main/java/com/zerobase/accountbook/controller/dailypayments/DailyPaymentsController.java
@@ -13,6 +13,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -62,7 +63,7 @@ public class DailyPaymentsController {
             @PathVariable Long dailyPaymentsId
     ) {
         GetDailyPaymentsResponseDto response =
-                dailyPaymentsService.getDailyPayments(
+                dailyPaymentsService.getDailyPayment(
                         user.getUsername(),
                         dailyPaymentsId
                 );
@@ -71,10 +72,14 @@ public class DailyPaymentsController {
 
     @GetMapping("/list")
     public ApiResponse<List<GetDailyPaymentsResponseDto>> getDailyPaymentsList(
-            @AuthenticationPrincipal UserDetails user
+            @AuthenticationPrincipal UserDetails user,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM") String date
     ) {
         List<GetDailyPaymentsResponseDto> response =
-                dailyPaymentsService.getDailyPaymentsList(user.getUsername());
+                dailyPaymentsService.getDailyPaymentsList(
+                        user.getUsername(),
+                        date
+                );
         return ApiResponse.success(response);
     }
 

--- a/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/response/ModifyDailyPaymentsResponseDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/dailypayments/dto/response/ModifyDailyPaymentsResponseDto.java
@@ -24,7 +24,6 @@ public class ModifyDailyPaymentsResponseDto {
 
     private String updatedAt;
 
-    // hashTags 는 추후에 수정할 예정
     public static ModifyDailyPaymentsResponseDto of(DailyPayments dailyPayments) {
         return ModifyDailyPaymentsResponseDto.builder()
                 .dailyPaymentsId(dailyPayments.getId())

--- a/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPaymentsRepository.java
+++ b/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPaymentsRepository.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 public interface DailyPaymentsRepository extends JpaRepository<DailyPayments, Long> {
 
+    List<DailyPayments> findAllByMemberIdAndCreatedAtContaining(Long memberId, String createdAt);
+
     @Query(
             nativeQuery = true,
             value = "select * " +

--- a/src/test/java/com/zerobase/accountbook/service/dailypaymetns/DailyPaymentsServiceTest.java
+++ b/src/test/java/com/zerobase/accountbook/service/dailypaymetns/DailyPaymentsServiceTest.java
@@ -1,0 +1,670 @@
+package com.zerobase.accountbook.service.dailypaymetns;
+
+import com.zerobase.accountbook.common.exception.model.AccountBookException;
+import com.zerobase.accountbook.controller.dailypayments.dto.request.CreateDailyPaymentsRequestDto;
+import com.zerobase.accountbook.controller.dailypayments.dto.request.DeleteDailyPaymentsRequestDto;
+import com.zerobase.accountbook.controller.dailypayments.dto.request.ModifyDailyPaymentsRequestDto;
+import com.zerobase.accountbook.controller.dailypayments.dto.response.CreateDailyPaymentsResponseDto;
+import com.zerobase.accountbook.controller.dailypayments.dto.response.GetDailyPaymentsResponseDto;
+import com.zerobase.accountbook.controller.dailypayments.dto.response.ModifyDailyPaymentsResponseDto;
+import com.zerobase.accountbook.domain.dailypayments.DailyPayments;
+import com.zerobase.accountbook.domain.dailypayments.DailyPaymentsRepository;
+import com.zerobase.accountbook.domain.member.Member;
+import com.zerobase.accountbook.domain.member.MemberRepository;
+import com.zerobase.accountbook.service.dailypaymetns.querydsl.DailyPaymentsQueryDsl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DailyPaymentsServiceTest {
+
+    @Mock
+    private DailyPaymentsQueryDsl dailyPaymentsQueryDsl;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private DailyPaymentsRepository dailyPaymentsRepository;
+
+    @InjectMocks
+    private DailyPaymentsService dailyPaymentsService;
+
+    @Test
+    void success_createDailyPayments() {
+        //given
+        String requestEmail = "hello@abc.com";
+        Member member = Member.builder()
+                .email(requestEmail)
+                .build();
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+
+        DailyPayments dailyPayments = DailyPayments.builder()
+                .paidAmount(1000)
+                .paidWhere("place1")
+                .methodOfPayment("card1")
+                .categoryName("category1")
+                .memo("memo1")
+                .build();
+        given(dailyPaymentsRepository.save(any()))
+                .willReturn(dailyPayments);
+
+        CreateDailyPaymentsRequestDto requestDto =
+                CreateDailyPaymentsRequestDto.builder()
+                        .paidAmount(1000)
+                        .paidWhere("place1")
+                        .methodOfPayment("card1")
+                        .categoryName("category1")
+                        .memo("memo1")
+                        .build();
+
+        ArgumentCaptor<DailyPayments> captor =
+                ArgumentCaptor.forClass(DailyPayments.class);
+
+        //when
+        CreateDailyPaymentsResponseDto responseDto =
+                dailyPaymentsService.createDailyPayments(
+                        requestEmail,
+                        requestDto
+                );
+
+        //then
+        verify(dailyPaymentsRepository, times(1))
+                .save(captor.capture());
+        // captor 에 id가 없다. 왜지?
+        assertEquals(
+                captor.getValue().getId(),
+                responseDto.getDailyPaymentsId()
+        );
+        assertEquals(
+                captor.getValue().getPaidAmount(),
+                responseDto.getPaidAmount()
+        );
+        assertEquals(
+                captor.getValue().getPaidWhere(),
+                responseDto.getPaidWhere()
+        );
+        assertEquals(
+                captor.getValue().getCategoryName(),
+                responseDto.getCategoryName()
+        );
+        assertEquals(
+                captor.getValue().getMethodOfPayment(),
+                responseDto.getMethodOfPayment()
+        );
+        assertEquals(
+                captor.getValue().getMemo(),
+                responseDto.getMemo()
+        );
+    }
+
+    @Test
+    void fail_createDailyPayments_존재하지_않는_회원() {
+        //given
+        String requestEmail = "hello@abc.com";
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.empty());
+
+        CreateDailyPaymentsRequestDto requestDto =
+                CreateDailyPaymentsRequestDto.builder()
+                        .paidAmount(1000)
+                        .paidWhere("place1")
+                        .methodOfPayment("card1")
+                        .categoryName("category1")
+                        .memo("memo1")
+                        .build();
+
+        //when
+
+        //then
+        assertThrows(AccountBookException.class,
+                () -> dailyPaymentsService.createDailyPayments(
+                        requestEmail, requestDto
+                )
+        );
+    }
+
+    @Test
+    void success_modifyDailyPayments() {
+        //given
+        String requestEmail = "hello@abc.com";
+        Member owner = Member.builder()
+                .id(1L)
+                .email(requestEmail)
+                .build();
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(owner));
+
+        DailyPayments dailyPayments = DailyPayments.builder()
+                .id(1L)
+                .member(owner)
+                .paidAmount(1000)
+                .paidWhere("place1")
+                .methodOfPayment("card1")
+                .categoryName("category1")
+                .memo("memo1")
+                .build();
+        given(dailyPaymentsRepository.save(any()))
+                .willReturn(dailyPayments);
+        given(dailyPaymentsRepository.findById(anyLong()))
+                .willReturn(Optional.of(dailyPayments));
+
+        ModifyDailyPaymentsRequestDto requestDto =
+                ModifyDailyPaymentsRequestDto.builder()
+                    .dailyPaymentsId(1L)
+                    .paidAmount(2000)
+                    .paidWhere("place2")
+                    .methodOfPayment("card2")
+                    .categoryName("category2")
+                    .memo("memo2")
+                    .build();
+
+        ArgumentCaptor<DailyPayments> captor =
+                ArgumentCaptor.forClass(DailyPayments.class);
+
+        //when
+        ModifyDailyPaymentsResponseDto responseDto =
+                dailyPaymentsService.modifyDailyPayments(
+                        requestEmail,
+                        requestDto
+                );
+
+        //then
+        verify(dailyPaymentsRepository, times(1))
+                .save(captor.capture());
+        assertEquals(
+                captor.getValue().getId(),
+                responseDto.getDailyPaymentsId()
+        );
+        assertEquals(
+                captor.getValue().getPaidAmount(),
+                responseDto.getPaidAmount()
+        );
+        assertEquals(
+                captor.getValue().getPaidWhere(),
+                responseDto.getPaidWhere()
+        );
+        assertEquals(
+                captor.getValue().getMethodOfPayment(),
+                responseDto.getMethodOfPayment()
+        );
+        assertEquals(
+                captor.getValue().getCategoryName(),
+                responseDto.getCategoryName()
+        );
+        assertEquals(
+                captor.getValue().getMemo(),
+                responseDto.getMemo()
+        );
+    }
+
+    @Test
+    void fail_modifyDailyPayments_존재하지_않는_회원() {
+        //given
+        String requestEmail = "hello@abc.com";
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.empty());
+
+        ModifyDailyPaymentsRequestDto requestDto =
+                ModifyDailyPaymentsRequestDto.builder()
+                        .dailyPaymentsId(1L)
+                        .paidAmount(2000)
+                        .paidWhere("place2")
+                        .methodOfPayment("card2")
+                        .categoryName("category2")
+                        .memo("memo2")
+                        .build();
+
+        //when
+
+        //then
+        assertThrows(AccountBookException.class,
+                () -> dailyPaymentsService.modifyDailyPayments(
+                        requestEmail,
+                        requestDto
+                )
+        );
+    }
+
+    @Test
+    void fail_modifyDailyPayments_존재하지_않는_지출내역() {
+        //given
+        String requestEmail = "hello@abc.com";
+        Member member = Member.builder()
+                .id(1L)
+                .email(requestEmail)
+                .build();
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+
+        given(dailyPaymentsRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+
+        ModifyDailyPaymentsRequestDto requestDto =
+                ModifyDailyPaymentsRequestDto.builder()
+                        .dailyPaymentsId(1L)
+                        .paidAmount(2000)
+                        .paidWhere("place2")
+                        .methodOfPayment("card2")
+                        .categoryName("category2")
+                        .memo("memo2")
+                        .build();
+
+        //when
+
+        //then
+        assertThrows(AccountBookException.class,
+                () -> dailyPaymentsService.modifyDailyPayments(
+                        requestEmail,
+                        requestDto
+                )
+        );
+    }
+
+    @Test
+    void fail_modifyDailyPayments_지출내역_주인이_아닌_경우() {
+        //given
+        String notOwnerEmail = "notOwner@abc.com";
+        Member owner = Member.builder()
+                .id(1L)
+                .email("owner@abc.com")
+                .build();
+        Member notOwner = Member.builder()
+                .id(2L)
+                .email(notOwnerEmail)
+                .build();
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(notOwner));
+
+        DailyPayments dailyPayments = DailyPayments.builder()
+                .id(1L)
+                .member(owner)
+                .paidAmount(1000)
+                .paidWhere("place1")
+                .methodOfPayment("card1")
+                .categoryName("category1")
+                .memo("memo1")
+                .build();
+
+        given(dailyPaymentsRepository.findById(anyLong()))
+                .willReturn(Optional.of(dailyPayments));
+
+        ModifyDailyPaymentsRequestDto requestDto =
+                ModifyDailyPaymentsRequestDto.builder()
+                        .dailyPaymentsId(1L)
+                        .paidAmount(2000)
+                        .paidWhere("place2")
+                        .methodOfPayment("card2")
+                        .categoryName("category2")
+                        .memo("memo2")
+                        .build();
+
+        //when
+
+        //then
+        assertThrows(AccountBookException.class,
+                () -> dailyPaymentsService.modifyDailyPayments(
+                        notOwnerEmail,
+                        requestDto
+                )
+        );
+    }
+
+    @Test
+    void success_deleteDailyPayments() {
+        //given
+        String requestEmail = "hello@abc.com";
+        Member owner = Member.builder()
+                .id(1L)
+                .email(requestEmail)
+                .build();
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(owner));
+
+        DailyPayments dailyPayments = DailyPayments.builder()
+                .id(1L)
+                .member(owner)
+                .paidAmount(1000)
+                .paidWhere("place1")
+                .methodOfPayment("card1")
+                .categoryName("category1")
+                .memo("memo1")
+                .build();
+        given(dailyPaymentsRepository.findById(anyLong()))
+                .willReturn(Optional.of(dailyPayments));
+
+        DeleteDailyPaymentsRequestDto requestDto =
+                DeleteDailyPaymentsRequestDto.builder()
+                        .dailyPaymentsId(1L)
+                        .build();
+
+        ArgumentCaptor<DailyPayments> captor =
+                ArgumentCaptor.forClass(DailyPayments.class);
+
+        //when
+        dailyPaymentsService.deleteDailyPayments(requestEmail, requestDto);
+
+        //then
+        verify(dailyPaymentsRepository, times(1))
+                .delete(captor.capture());
+    }
+
+    @Test
+    void fail_deleteDailyPayments_존재하지_않는_회원() {
+        //given
+        String requestEmail = "hello@abc.com";
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.empty());
+
+        DeleteDailyPaymentsRequestDto requestDto =
+                DeleteDailyPaymentsRequestDto.builder()
+                        .dailyPaymentsId(1L)
+                        .build();
+
+        //when
+
+        //then
+        assertThrows(AccountBookException.class,
+                () -> dailyPaymentsService.deleteDailyPayments(
+                        requestEmail,
+                        requestDto
+                )
+        );
+    }
+
+    @Test
+    void fail_deleteDailyPayments_존재하지_않는_지출내역() {
+        //given
+        String requestEmail = "hello@abc.com";
+        Member owner = Member.builder()
+                .id(1L)
+                .email(requestEmail)
+                .build();
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(owner));
+
+        given(dailyPaymentsRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+
+        DeleteDailyPaymentsRequestDto requestDto =
+                DeleteDailyPaymentsRequestDto.builder()
+                        .dailyPaymentsId(1L)
+                        .build();
+
+        //when
+
+        //then
+        assertThrows(AccountBookException.class,
+                () -> dailyPaymentsService.deleteDailyPayments(
+                        requestEmail,
+                        requestDto
+                )
+        );
+    }
+
+    @Test
+    void fail_deleteDailyPayments_지출내역_주인이_아닌_경우() {
+        //given
+        String notOwnerEmail = "notOwner@abc.com";
+        Member owner = Member.builder()
+                .id(1L)
+                .email("owner@abc.com")
+                .build();
+        Member notOwner = Member.builder()
+                .id(2L)
+                .email(notOwnerEmail)
+                .build();
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(notOwner));
+
+        DailyPayments dailyPayments = DailyPayments.builder()
+                .id(1L)
+                .member(owner)
+                .paidAmount(1000)
+                .paidWhere("place1")
+                .methodOfPayment("card1")
+                .categoryName("category1")
+                .memo("memo1")
+                .build();
+
+        given(dailyPaymentsRepository.findById(anyLong()))
+                .willReturn(Optional.of(dailyPayments));
+
+        DeleteDailyPaymentsRequestDto requestDto =
+                DeleteDailyPaymentsRequestDto.builder()
+                        .dailyPaymentsId(1L)
+                        .build();
+
+        //when
+
+        //then
+        assertThrows(AccountBookException.class,
+                () -> dailyPaymentsService.deleteDailyPayments(
+                        notOwnerEmail,
+                        requestDto
+                )
+        );
+    }
+
+    @Test
+    void success_getDailyPayment() {
+        //given
+        String requestEmail = "hello@abc.com";
+        Member owner = Member.builder()
+                .id(1L)
+                .email(requestEmail)
+                .build();
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(owner));
+
+        DailyPayments dailyPayments = DailyPayments.builder()
+                .id(1L)
+                .member(owner)
+                .paidAmount(1000)
+                .paidWhere("place1")
+                .methodOfPayment("card1")
+                .categoryName("category1")
+                .memo("memo1")
+                .build();
+        given(dailyPaymentsRepository.findById(anyLong()))
+                .willReturn(Optional.of(dailyPayments));
+
+
+        //when
+        GetDailyPaymentsResponseDto responseDto =
+                dailyPaymentsService.getDailyPayment(
+                        requestEmail,
+                        dailyPayments.getId()
+                );
+
+        //then
+        assertEquals(
+                dailyPayments.getPaidAmount(),
+                responseDto.getPaidAmount()
+        );
+        assertEquals(
+                dailyPayments.getPaidWhere(),
+                responseDto.getPaidWhere()
+        );
+        assertEquals(
+                dailyPayments.getMethodOfPayment(),
+                responseDto.getMethodOfPayment()
+        );
+        assertEquals(
+                dailyPayments.getCategoryName(),
+                responseDto.getCategoryName()
+        );
+        assertEquals(
+                dailyPayments.getMemo(),
+                responseDto.getMemo()
+        );
+    }
+
+    @Test
+    void fail_getDailyPayment_존재하지_않는_회원() {
+        //given
+        String requestEmail = "hello@abc.com";
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.empty());
+
+        Long requestDailyPaymentsId = 1L;
+
+        //when
+
+        //then
+        assertThrows(AccountBookException.class,
+                () -> dailyPaymentsService.getDailyPayment(
+                        requestEmail,
+                        requestDailyPaymentsId
+                )
+        );
+    }
+
+    @Test
+    void fail_getDailyPayment_존재하지_않는_지출내역() {
+        //given
+        String requestEmail = "hello@abc.com";
+        Member owner = Member.builder()
+                .id(1L)
+                .email(requestEmail)
+                .build();
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(owner));
+
+        given(dailyPaymentsRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+
+        Long requestDailyPaymentsId = 1L;
+
+        //when
+
+        //then
+        assertThrows(AccountBookException.class,
+                () -> dailyPaymentsService.getDailyPayment(
+                        requestEmail,
+                        requestDailyPaymentsId
+                )
+        );
+    }
+
+    @Test
+    void fail_getDailyPayment_지출내역_주인이_아닌_경우() {
+        //given
+        String notOwnerEmail = "notOwner@abc.com";
+        Member owner = Member.builder()
+                .id(1L)
+                .email("owner@abc.com")
+                .build();
+        Member notOwner = Member.builder()
+                .id(2L)
+                .email(notOwnerEmail)
+                .build();
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(notOwner));
+
+        DailyPayments dailyPayments = DailyPayments.builder()
+                .id(1L)
+                .member(owner)
+                .paidAmount(1000)
+                .paidWhere("place1")
+                .methodOfPayment("card1")
+                .categoryName("category1")
+                .memo("memo1")
+                .build();
+
+        given(dailyPaymentsRepository.findById(anyLong()))
+                .willReturn(Optional.of(dailyPayments));
+
+        //when
+
+        //then
+        assertThrows(AccountBookException.class,
+                () -> dailyPaymentsService.getDailyPayment(
+                        notOwnerEmail,
+                        dailyPayments.getId()
+                )
+        );
+    }
+
+    @Test
+    void success_getDailyPaymentsList() {
+        //given
+        String requestDate = "yyyy-MM";
+
+        String requestEmail = "hello@abc.com";
+        Member owner = Member.builder()
+                .email(requestEmail)
+                .build();
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(owner));
+
+        DailyPayments dailyPayment1 = DailyPayments.builder()
+                .id(1L)
+                .member(owner)
+                .paidAmount(1000)
+                .paidWhere("place1")
+                .methodOfPayment("card1")
+                .categoryName("category1")
+                .memo("memo1")
+                .build();
+        DailyPayments dailyPayment2 = DailyPayments.builder()
+                .id(2L)
+                .member(owner)
+                .paidAmount(2000)
+                .paidWhere("place2")
+                .methodOfPayment("card2")
+                .categoryName("category2")
+                .memo("memo2")
+                .build();
+        List<DailyPayments> dailyPaymentsList = new ArrayList<>();
+        dailyPaymentsList.add(dailyPayment1);
+        dailyPaymentsList.add(dailyPayment2);
+        given(dailyPaymentsRepository.findAllByMemberIdAndCreatedAtContaining(
+                owner.getId(),
+                requestDate
+                )
+        )
+                .willReturn(dailyPaymentsList);
+
+        //when
+        List<GetDailyPaymentsResponseDto> responseDtoList =
+                dailyPaymentsService.getDailyPaymentsList(requestEmail, requestDate);
+
+        //then
+        assertEquals(2, responseDtoList.size());
+    }
+
+    @Test
+    void fail_getDailyPaymentsList_존재하지_않는_회원() {
+        //given
+        String requestDate = "yyyy-MM";
+
+        String requestEmail = "hello@abc.com";
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.empty());
+
+        //when
+
+        //then
+        assertThrows(AccountBookException.class,
+                () -> dailyPaymentsService.getDailyPaymentsList(
+                        requestEmail,
+                        requestDate)
+        );
+    }
+}


### PR DESCRIPTION
### 📍 변경사항
기존에 구현했던 매일 지출내역 서비스 클래스의 CRUD 테스트 코드를 작성했습니다. 

### 📍 AS - IS

1.  매일 지출내역 생성 테스트
* 성공 케이스 
* 실패 케이스  
    * 존재하지 않는 회원일 경우
2. 매일 지출내역 수정 테스트 
* 성공 케이스 
* 실패 케이스  
    * 존재하지 않는 회원일 경우
    * 매일 지출내역이 존재하지 않는 경우
    * 매일 지출내역의 주인이 아닌 경우
3. 매일 지출내역 삭제 테스트 
* 성공 케이스 
* 실패 케이스  
    * 존재하지 않는 회원일 경우
    * 매일 지출내역이 존재하지 않는 경우
    * 매일 지출내역의 주인이 아닌 경우
4. 매일 지출내역 조회 테스트 
* 성공 케이스 
* 실패 케이스  
    * 존재하지 않는 회원일 경우
    * 매일 지출내역이 존재하지 않는 경우
    * 매일 지출내역의 주인이 아닌 경우
5. 매일 지출내역 리스트 조회 테스트 
* 성공 케이스 
* 실패 케이스  
    * 존재하지 않는 회원일 경우

### 📍 TO - BE

### 📍 테스트
- [x]  단위 테스트