### PR TITLE
[test] issue#7 DailyPaymentsService 키워드를 이용한 검색기능 테스트 코드 작성

### DIFF
--- a/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPayments.java
+++ b/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPayments.java
@@ -38,6 +38,5 @@ public class DailyPayments {
 
     @LastModifiedDate
     private String updatedAt;
-
 }
 

--- a/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPaymentsRepository.java
+++ b/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPaymentsRepository.java
@@ -19,8 +19,6 @@ public interface DailyPaymentsRepository extends JpaRepository<DailyPayments, Lo
     )
     List<DailyPayments> searchKeyword(long memberId, String keyword);
 
-    List<DailyPayments> findByMemberIdAndCreatedAtBetween(Long memberId, String before, String now);
-
     @Query(
             nativeQuery = true,
             value = "select sum(dp.paid_amount) " +


### PR DESCRIPTION
### 📍 변경사항
기존에 구현했던 매일 지출내역 서비스 클래스의 검색 기능의 테스트 코드를 작성했습니다. 

### 📍 AS - IS

1. 검색 테스트 
* 성공 케이스 
    * 검색한 사용자의 매일 지출내역 중에서 검색
    * 메모와 지출 장소에 키워드가 포함되는 지출내역 조회  
* 실패 케이스  
    * 존재하지 않는 회원일 경우

### 📍 TO - BE
테스트 코드 작성이 아직 미숙해 부족한 점이 있는 것 같습니다. 
이 부분은 추후에 공부 후 보완할 예정입니다.

### 📍 테스트
- [x]  단위 테스트