### PR TITLE
[test] issue#12 DailyPaymentsService 한달/1년 지출내역 조회 기능 테스트 코드 작성

### DIFF
--- a/src/main/java/com/zerobase/accountbook/service/dailypaymetns/dto/DailyPaymentsCategoryDto.java
+++ b/src/main/java/com/zerobase/accountbook/service/dailypaymetns/dto/DailyPaymentsCategoryDto.java
@@ -1,12 +1,14 @@
 package com.zerobase.accountbook.service.dailypaymetns.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
 public class DailyPaymentsCategoryDto {
 

--- a/src/test/java/com/zerobase/accountbook/service/dailypaymetns/DailyPaymentsServiceTest.java
+++ b/src/test/java/com/zerobase/accountbook/service/dailypaymetns/DailyPaymentsServiceTest.java
@@ -4,15 +4,18 @@ import com.zerobase.accountbook.common.exception.model.AccountBookException;
 import com.zerobase.accountbook.controller.dailypayments.dto.request.CreateDailyPaymentsRequestDto;
 import com.zerobase.accountbook.controller.dailypayments.dto.request.DeleteDailyPaymentsRequestDto;
 import com.zerobase.accountbook.controller.dailypayments.dto.request.ModifyDailyPaymentsRequestDto;
-import com.zerobase.accountbook.controller.dailypayments.dto.response.CreateDailyPaymentsResponseDto;
-import com.zerobase.accountbook.controller.dailypayments.dto.response.GetDailyPaymentsResponseDto;
-import com.zerobase.accountbook.controller.dailypayments.dto.response.ModifyDailyPaymentsResponseDto;
-import com.zerobase.accountbook.controller.dailypayments.dto.response.SearchDailyPaymentsResponseDto;
+import com.zerobase.accountbook.controller.dailypayments.dto.response.*;
 import com.zerobase.accountbook.domain.dailypayments.DailyPayments;
 import com.zerobase.accountbook.domain.dailypayments.DailyPaymentsRepository;
 import com.zerobase.accountbook.domain.member.Member;
 import com.zerobase.accountbook.domain.member.MemberRepository;
+import com.zerobase.accountbook.domain.monthlytotalamount.MonthlyTotalAmount;
+import com.zerobase.accountbook.domain.monthlytotalamount.MonthlyTotalAmountRepository;
+import com.zerobase.accountbook.domain.totalamountpercategory.TotalAmountPerCategory;
+import com.zerobase.accountbook.domain.totalamountpercategory.TotalAmountPerCategoryRepository;
+import com.zerobase.accountbook.service.dailypaymetns.dto.DailyPaymentsCategoryDto;
 import com.zerobase.accountbook.service.dailypaymetns.querydsl.DailyPaymentsQueryDsl;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -35,12 +38,18 @@ import static org.mockito.Mockito.verify;
 class DailyPaymentsServiceTest {
 
     @Mock
+    private MonthlyTotalAmountRepository monthlyTotalAmountRepository;
+
+    @Mock
+    private TotalAmountPerCategoryRepository totalAmountPerCategoryRepository;
+
+    @Mock
     private DailyPaymentsQueryDsl dailyPaymentsQueryDsl;
 
     @Mock
     private MemberRepository memberRepository;
 
-    @Spy
+    @Mock
     private DailyPaymentsRepository dailyPaymentsRepository;
 
     @InjectMocks
@@ -764,6 +773,152 @@ class DailyPaymentsServiceTest {
                 () -> dailyPaymentsService.searchDailyPayments(
                         requestEmail,
                         requestKeyword)
+        );
+    }
+
+    @Test
+    @DisplayName("성공_지출내역_통계_조회_지난달")
+    void success_getMonthlyDailyPaymentsResult_getPastMonthlyResult() {
+        //given
+        String requestEmail = "hello@abc.com";
+        String requestDate = "2022-12";
+        Member member = Member.builder()
+                .id(1L)
+                .email(requestEmail)
+                .build();
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+
+        MonthlyTotalAmount monthlyTotalAmount = MonthlyTotalAmount.builder()
+                .totalAmount(1000000)
+                .build();
+        given(monthlyTotalAmountRepository.findByDateInfoAndMemberId(
+                anyString(),
+                anyLong())
+        ).willReturn(Optional.of(monthlyTotalAmount));
+
+        TotalAmountPerCategory totalAmountPerCategory =
+                TotalAmountPerCategory.builder()
+                    .member(member)
+                    .categoryName("categoryName1")
+                    .totalAmount(10000)
+                    .build();
+        List<TotalAmountPerCategory> list = new ArrayList<>();
+        list.add(totalAmountPerCategory);
+        given(totalAmountPerCategoryRepository.findByDateInfoAndMemberId(
+                anyString(),
+                anyLong()
+                )
+        ).willReturn(list);
+
+        //when
+        GetMonthlyResultResponseDto responseDto =
+                dailyPaymentsService.getMonthlyDailyPaymentsResult(
+                        requestEmail,
+                        requestDate
+                );
+
+        //then
+        assertEquals(
+                monthlyTotalAmount.getTotalAmount(),
+                responseDto.getTotalAmount()
+        );
+        assertEquals(1, responseDto.getList().size());
+    }
+
+    @Test
+    @DisplayName("성공_지출내역_통계_조회_이번달")
+    void success_getMonthlyDailyPaymentsResult_getCurrentMonthlyResult() {
+        //given
+        String requestEmail = "hello@abc.com";
+        String requestDate = "2023-01";
+        Member member = Member.builder()
+                .id(1L)
+                .email(requestEmail)
+                .build();
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+
+        DailyPaymentsCategoryDto categoryDto1 = DailyPaymentsCategoryDto.builder()
+                .categoryName("category1")
+                .totalAmount(12345)
+                .build();
+        DailyPaymentsCategoryDto categoryDto2 = DailyPaymentsCategoryDto.builder()
+                .categoryName("category2")
+                .totalAmount(67890)
+                .build();
+        List<DailyPaymentsCategoryDto> list = new ArrayList<>();
+        list.add(categoryDto1);
+        list.add(categoryDto2);
+        given(dailyPaymentsQueryDsl
+                .getTotalAmountPerCategoryByMemberId(anyString(), anyLong())
+        ).willReturn(list);
+
+
+        //when
+        GetMonthlyResultResponseDto responseDto =
+                dailyPaymentsService.getMonthlyDailyPaymentsResult(
+                        requestEmail,
+                        requestDate
+                );
+
+        //then
+        assertEquals(
+                categoryDto1.getTotalAmount() + categoryDto2.getTotalAmount(),
+                responseDto.getTotalAmount()
+        );
+        assertEquals(list.size(), responseDto.getList().size());
+    }
+
+    @Test
+    @DisplayName("실패_지출내역_통계_조회_존재하지_않는_회원일_때")
+    void fail_getMonthlyDailyPaymentsResult_존재하지_않는_회원() {
+        //given
+        String requestEmail = "hello@abc.com";
+        String requestDate = "yyyy-MM";
+
+
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.empty());
+
+        //when
+
+        //then
+        assertThrows(AccountBookException.class,
+                () -> dailyPaymentsService.getMonthlyDailyPaymentsResult(
+                        requestEmail,
+                        requestDate
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("실패_지난달_지출내역_통계_조회_총_지출이_존재하지_않을_때")
+    void fail_getPastMonthlyResult_총_지출이_존재하지_않을_때() {
+        //given
+        String requestEmail = "hello@abc.com";
+        String requestDate = "2022-12";
+
+        Member member = Member.builder()
+                .id(1L)
+                .email(requestEmail)
+                .build();
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+
+        given(monthlyTotalAmountRepository.findByDateInfoAndMemberId(
+                anyString(), anyLong()
+            )
+        ).willReturn(Optional.empty());
+
+        //when
+
+        //then
+        assertThrows(AccountBookException.class,
+                () -> dailyPaymentsService.getMonthlyDailyPaymentsResult(
+                        requestEmail,
+                        requestDate
+                )
         );
     }
 }


### PR DESCRIPTION
### 📍 변경사항
기존에 구현했던 매일 지출내역 서비스 클래스의 한달/1년 지출내역 조회 기능에 대한 테스트 코드를 작성했습니다. 

### 📍 AS - IS

1.  한달 지출내역 조회-지난 달
* 성공 케이스 
* 실패 케이스  
    * 존재하지 않는 회원일 경우
    * 지난 달 총 지출이 존재하지 않는 경우
2.  한달 지출내역 조회-이번 달
* 성공 케이스 
* 실패 케이스  
    * 존재하지 않는 회원일 경우
3. 1년 지출내역 조회 
* 작년 지출내역부터 1년 단위로 조회 가능합니다.
* 성공 케이스 
* 실패 케이스  
    * 존재하지 않는 회원일 경우
    * 조회할 수 없는 년도일 경우(올해, 내년,,,,)

### 📍 TO - BE
- [ ] 한달 지출내역 조회 메서드 로직의 응집도가 낮은 것 같아 리팩토링이 필요할 것 같습니다. 

### 📍 테스트
- [x]  단위 테스트