### PR TITLE
Issue#25 [feat] AccountBook 프로젝트 마무리 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation group: 'com.google.firebase', name: 'firebase-admin', version: '8.1.0'
 	implementation group:'com.squareup.okhttp3', name: 'okhttp', version: '4.2.2'
+	implementation 'io.springfox:springfox-swagger2:2.9.2'
+	implementation 'io.springfox:springfox-swagger-ui:2.9.2'
 	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
 	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/zerobase/accountbook/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/zerobase/accountbook/common/config/security/SecurityConfig.java
@@ -41,7 +41,12 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
-                .antMatchers("/v1/**").permitAll()
+                .antMatchers(
+                        "/v1/**",
+                        "/swagger-resources/**",
+                        "/swagger-ui.html",
+                        "/swagger-ui/**"
+                ).permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),

--- a/src/main/java/com/zerobase/accountbook/common/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/zerobase/accountbook/common/config/swagger/SwaggerConfig.java
@@ -1,0 +1,33 @@
+package com.zerobase.accountbook.common.config.swagger;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("zerobase.accountbook"))
+                .paths(PathSelectors.any())
+                .build().apiInfo(apiInfo());
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("김예진 개인프로젝트 - 짠짠이 입니다 :)")
+                .description("오늘 하루 소비한 내역을 저장해 가계부를 작성할 수 있어요.")
+                .version("2.0")
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/accountbook/controller/member/MemberController.java
+++ b/src/main/java/com/zerobase/accountbook/controller/member/MemberController.java
@@ -6,6 +6,7 @@ import com.zerobase.accountbook.controller.auth.dto.request.ModifyMemberPassword
 import com.zerobase.accountbook.controller.auth.dto.response.GetMemberInfoResponseDto;
 import com.zerobase.accountbook.controller.auth.dto.response.ModifyMemberInfoResponseDto;
 import com.zerobase.accountbook.controller.auth.dto.response.ModifyMemberPasswordResponseDto;
+import com.zerobase.accountbook.controller.member.dto.request.DeleteMemberRequestDto;
 import com.zerobase.accountbook.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -49,5 +50,14 @@ public class MemberController {
         ModifyMemberPasswordResponseDto response =
                 memberService.modifyMemberPassword(user.getUsername(), request);
         return ApiResponse.success(response);
+    }
+
+    @DeleteMapping
+    public ApiResponse<String> deleteMember(
+            @AuthenticationPrincipal UserDetails user,
+            @RequestBody DeleteMemberRequestDto request
+    ) {
+        memberService.deleteMember(user.getUsername(), request);
+        return ApiResponse.SUCCESS;
     }
 }

--- a/src/main/java/com/zerobase/accountbook/controller/member/dto/request/DeleteMemberRequestDto.java
+++ b/src/main/java/com/zerobase/accountbook/controller/member/dto/request/DeleteMemberRequestDto.java
@@ -1,0 +1,13 @@
+package com.zerobase.accountbook.controller.member.dto.request;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteMemberRequestDto {
+
+    private Long memberId;
+
+}

--- a/src/main/java/com/zerobase/accountbook/domain/budget/BudgetRepository.java
+++ b/src/main/java/com/zerobase/accountbook/domain/budget/BudgetRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 public interface BudgetRepository extends JpaRepository<Budget, Long> {
 
     Optional<Budget> findByBudgetYearMonth(String budgetYearMonth);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/zerobase/accountbook/domain/category/CategoryRepository.java
+++ b/src/main/java/com/zerobase/accountbook/domain/category/CategoryRepository.java
@@ -10,4 +10,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     boolean existsByCategoryName(String categoryName);
 
     List<Category> findAllByMemberId(Long memberId);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPaymentsRepository.java
+++ b/src/main/java/com/zerobase/accountbook/domain/dailypayments/DailyPaymentsRepository.java
@@ -26,4 +26,6 @@ public interface DailyPaymentsRepository extends JpaRepository<DailyPayments, Lo
                     "and dp.created_at like :date%"
     )
     int totalPaidAmountSoFarByMemberId(Long memberId, String date);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/zerobase/accountbook/domain/member/MemberRepository.java
+++ b/src/main/java/com/zerobase/accountbook/domain/member/MemberRepository.java
@@ -15,4 +15,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Long countBy();
 
     Page<Member> findAll(Pageable pageable);
+
+    void deleteAllById(Long memberId);
 }

--- a/src/main/java/com/zerobase/accountbook/domain/monthlytotalamount/MonthlyTotalAmountRepository.java
+++ b/src/main/java/com/zerobase/accountbook/domain/monthlytotalamount/MonthlyTotalAmountRepository.java
@@ -17,4 +17,6 @@ public interface MonthlyTotalAmountRepository extends JpaRepository<MonthlyTotal
                     "and mt.member_id = :memberId"
     )
     Integer sumByMemberIdAndDateInfoContainingYear(Long memberId, String year);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/zerobase/accountbook/domain/totalamountpercategory/TotalAmountPerCategoryRepository.java
+++ b/src/main/java/com/zerobase/accountbook/domain/totalamountpercategory/TotalAmountPerCategoryRepository.java
@@ -7,5 +7,7 @@ import java.util.List;
 public interface TotalAmountPerCategoryRepository extends JpaRepository<TotalAmountPerCategory, Long> {
 
     List<TotalAmountPerCategory> findByDateInfoAndMemberId(String dateInfo, Long memberId);
+
+    void deleteAllByMemberId(Long memberId);
 }
 

--- a/src/test/java/com/zerobase/accountbook/service/auth/AuthServiceTest.java
+++ b/src/test/java/com/zerobase/accountbook/service/auth/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.zerobase.accountbook.service.auth;
 
+import com.zerobase.accountbook.common.config.security.JwtTokenProvider;
 import com.zerobase.accountbook.common.config.security.dto.TokenResponseDto;
 import com.zerobase.accountbook.common.exception.model.AccountBookException;
 import com.zerobase.accountbook.common.repository.RedisRepository;
@@ -42,6 +43,9 @@ class AuthServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
 
     @InjectMocks
     private AuthService authService;
@@ -310,17 +314,17 @@ class AuthServiceTest {
         given(passwordEncoder.matches(password, member.getPassword()))
                 .willReturn(true);
 
-        ArgumentCaptor<TokenResponseDto> captor =
-                ArgumentCaptor.forClass(TokenResponseDto.class);
+        TokenResponseDto token = TokenResponseDto.builder()
+                .accessToken("token")
+                .build();
+        given(jwtTokenProvider.createToken(anyString(), anyList()))
+                .willReturn(token);
 
         //when
-        List<String> roles = new ArrayList<>();
-        roles.add(member.getRole().toString());
-        authService.signIn(email, password);
-
+        TokenResponseDto responseDto = authService.signIn(email, password);
 
         //then
-        assertNotNull(captor);
+        assertEquals(token.getAccessToken(), responseDto.getAccessToken());
     }
 
     @Test


### PR DESCRIPTION
### 📍 변경사항
개인 프로젝트 제출전 마무리하는 작업입니다. 

### 📍 AS - IS

1. 회원 탈퇴 구현
* 사용자 이메일과 삭제하려는 사용자 아이디를 전달합니다.
* 본인의 계정만 탈퇴 가능합니다. 
* 사용자 정보 뿐만 아니라 예산, 카테고리, 지출내역, 한달 총 지출내역, 1년 총 지축내역이 삭제됩니다. 

2. 회원 탈퇴 테스트 코드 작성
* 성공 케이스 
* 실패 케이스 
    * 존재하지 않는 회원을 삭제하는 경우
    * 본인이 아닌 다른 사용자의 계정을 삭제하려는 경우 

3. REST API 문서로 Swagger 연동


### 📍 TO - BE
- [ ] 프로젝트 README.md 작성 

### 📍 테스트
- [x] API Test
- [x]  단위 테스트
